### PR TITLE
Update cordova-sqlite-storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@ionic-native/splash-screen": "^5.0.0",
     "@ionic-native/status-bar": "^5.0.0",
     "@ionic/angular": "^4.0.0",
-    "cordova-sqlite-storage": "2.6.0",
+    "cordova-sqlite-storage": "3.2.0",
     "core-js": "^2.5.4",
     "rxjs": "~6.3.3",
     "sql.js": "^0.5.0",


### PR DESCRIPTION
cordova-sqlite-storage has a bug and currently fails during install on older version (pre 3.2.0)