### PR TITLE
Hotfix: Changes to the async initialization sequence, 

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,10 +4,6 @@ import { Platform } from '@ionic/angular';
 import { SplashScreen } from '@ionic-native/splash-screen/ngx';
 import { StatusBar } from '@ionic-native/status-bar/ngx';
 
-import { createConnection } from 'typeorm';
-import { DbService } from './services/db.service';
-
-
 @Component({
   selector: 'app-root',
   templateUrl: 'app.component.html'
@@ -17,7 +13,6 @@ export class AppComponent {
     private platform: Platform,
     private splashScreen: SplashScreen,
     private statusBar: StatusBar,
-    private dbService: DbService
   ) {
     this.initializeApp();
   }
@@ -27,7 +22,5 @@ export class AppComponent {
       this.statusBar.styleDefault();
       this.splashScreen.hide();
     });
-
-    await this.dbService.ready();
   }
 }

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -4,6 +4,7 @@ import { getRepository, Repository } from 'typeorm';
 import { Post } from 'src/app/entities/post';
 import { Category } from 'src/app/entities/category';
 import { Author } from 'src/app/entities/author';
+import { DbService } from 'src/app/services/db.service';
 
 @Component({
   selector: 'app-home',
@@ -14,13 +15,15 @@ export class HomePage implements OnInit {
   savedPost: boolean = false;
   loadedPost: Post = null;
 
-  constructor() { }
+  constructor(private dbService: DbService) { }
 
   ngOnInit() {
     this.runDemo();
   }
 
   async runDemo() {
+    await this.dbService.ready();
+
     const category1 = new Category();
     category1.name = "TypeScript";
 

--- a/src/app/services/db.service.ts
+++ b/src/app/services/db.service.ts
@@ -20,17 +20,8 @@ export class DbService {
   constructor(private platform: Platform) { }
 
   async ready() {
-    try {
-      
-      await getConnection();
-    
-    } catch (ex) {
-      
-      // console.log('Connection not established!', ex);
-
-      await this.createConnection();
-
-    }
+    await this.platform.ready();
+    await this.createConnection();
   }
 
   private createConnection(): Promise<Connection> {


### PR DESCRIPTION
### Hotfix: Changes to the async initialization sequence

Checked using Ionic 5.4.4 and Cordova 9.0.0 installed globally, deploying on an Android 9 (API level 28) emulator and an Android 7 device, both in 'dev' and 'prod' profiles.

This solves the

`'ERROR …Error: Uncaught (in promise): RepositoryNotFoundError: No repository for "post" was found. Looks like this entity is not registered in current default connection?'`

error, happening because the `getRepository('post')` call in [home.page](https://github.com/coturiv/ionic4-typeorm-starter/blob/62baf102dffcbc5ab3cfcf0ea5e0cfc9fdcf19cb/src/app/pages/home/home.page.ts#L39) would happen before the TypeORM connection created by the [db.service](https://github.com/coturiv/ionic4-typeorm-starter/blob/62baf102dffcbc5ab3cfcf0ea5e0cfc9fdcf19cb/src/app/services/db.service.ts#L66) was ready, despite trying to wait for its initialization in [app.component](https://github.com/coturiv/ionic4-typeorm-starter/blob/62baf102dffcbc5ab3cfcf0ea5e0cfc9fdcf19cb/src/app/app.component.ts#L31).

This is of course just a suggestion of correction, feel free to adapt as you wish.