### PR TITLE
Fix patch script for Mac OSX

### DIFF
--- a/scripts/patch.sh
+++ b/scripts/patch.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 # file: patch.sh
 
-replace() {    
-    sed -i "s/$1/$2/g" "$3"
+replace() {
+    # Explicitly specify file ending on Mac OSX.
+    # @see https://myshittycode.com/2014/07/24/os-x-sed-extra-characters-at-the-end-of-l-command-error/
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      sed -i "" "s/$1/$2/g" "$3"
+    else
+      sed -i "s/$1/$2/g" "$3"
+    fi
 }
 
 # ==========================


### PR DESCRIPTION
Avoid `sed` error `extra characters at the end of l command`